### PR TITLE
Add support for deserializing unordered arrays

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(missing_docs)]
+#![allow(clippy::float_cmp)]
 //! # PHP serialization format support for serde
 //!
 //! PHP uses a custom serialization format through its
@@ -176,7 +177,7 @@ mod de;
 mod error;
 mod ser;
 
-pub use de::from_bytes;
+pub use de::{deserialize_unordered_array, from_bytes};
 pub use error::{Error, Result};
 pub use ser::{to_vec, to_writer};
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -453,7 +453,6 @@ impl ser::SerializeStructVariant for NotImplemented {
 #[cfg(test)]
 mod tests {
     use super::to_vec;
-    use bson;
     use serde::Serialize;
     use std::collections::BTreeMap;
 


### PR DESCRIPTION
This PR does two things:

1. It fixes deserializing maps with integers as keys
2. It adds a helper `deserialize_unordered_array` to deserialize PHP arrays where the indexes are out of order.

To small changes are included to make clippy happy.